### PR TITLE
Add Parameters and Its Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,10 +3,19 @@
 ## About
 WLGEN pretends to be something between crunch and CUPP. Permutations are based on a list of keywords and then you can add different options (connectors,abbreviations, reverse, replacements ...) to extend the final wordlist.
 
-## Use
-There are seceral options in `config.cfg`:
+## Usage
+You can simply execute the following command to serve the purpose immediately. The default `config.cfg` will be the source of configuration and the `output.txt` will be created after the execution as a result. 
+`$ python iwlgen.py`
 
-### Params
+You can also set your custom configuration filename instead of using `config.cfg` and set the output filename as well.
+`$ python iwlgen.py -c <config_filename> -o <output_filename>`
+For example
+`$ python iwlgen.py -c myconfig.cfg -o myoutput.cfg`
+
+When using the parameters please use `-c` and `-o` parameters altogether, otherwise the script will use the default setting.
+
+### Configuration
+The following settings can be configured through `config.cfg`:
 - `keywords` (list): Main list to permutate.
 - `connectors` (list): For each permutation we will use this list to concatenate keywords.
 - `num_tails` (list): For each permutation we will add (at the end of the string) a number (`10`) or a range of numbers (`20-40`)

--- a/iwlgen.py
+++ b/iwlgen.py
@@ -1,4 +1,5 @@
 import time
+import optparse
 start = time.clock()
 
 import ConfigParser
@@ -37,8 +38,22 @@ def to_file(filename, wordlist):
   f.close()
   print "Saving wordlist ("+str(lines)+" words) to "+filename+"."
 
+parser = optparse.OptionParser("usage %prog "+\
+		"-c <configfile> -o <outputfile>")
+parser.add_option('-c', dest='confname', type='string',\
+			help='specify config filename')
+parser.add_option('-o', dest='outputname', type='string',\
+			help='specify output filename')
+(options, arg) = parser.parse_args()
+if (options.confname == None) | (options.outputname == None):
+	print parser.usage
+	exit(0)
+else:
+	confname = options.confname
+	outputname = options.outputname
+
 Config = ConfigParser.ConfigParser()
-Config.read("config.cfg")
+Config.read(confname)
 
 replacements = Config.items('Replacements');
 items = list(Config.get('Params','keywords').split(','))
@@ -47,7 +62,7 @@ num_tails = list(Config.get('Params','num_tails').split(','))
 tails = list(Config.get('Params','tails').split(','))
 min_lenght = Config.get('Options','min_length')
 max_lenght = Config.get('Options','max_length')
-output = Config.get('Files','output')
+output = outputname
 
 m = len(items)
 result = []

--- a/iwlgen.py
+++ b/iwlgen.py
@@ -38,6 +38,8 @@ def to_file(filename, wordlist):
   f.close()
   print "Saving wordlist ("+str(lines)+" words) to "+filename+"."
 
+Config = ConfigParser.ConfigParser()
+
 parser = optparse.OptionParser("usage %prog "+\
 		"-c <configfile> -o <outputfile>")
 parser.add_option('-c', dest='confname', type='string',\
@@ -46,14 +48,13 @@ parser.add_option('-o', dest='outputname', type='string',\
 			help='specify output filename')
 (options, arg) = parser.parse_args()
 if (options.confname == None) | (options.outputname == None):
-	print parser.usage
-	exit(0)
+	confname = 'config.cfg'
+	Config.read(confname)
+	outputname = Config.get('Files', 'output')
 else:
 	confname = options.confname
 	outputname = options.outputname
-
-Config = ConfigParser.ConfigParser()
-Config.read(confname)
+	Config.read(confname)
 
 replacements = Config.items('Replacements');
 items = list(Config.get('Params','keywords').split(','))


### PR DESCRIPTION
Add parameters to enable the following items:
- Custom config filename. If a user wants to utilize several configurations he won't bother with the config.cfg alone
- Custom output filename. To make user easier to save different output from different configuration.

The usage of parameters is being put under readme file

Thank you.